### PR TITLE
Dashboard view of podcasts and their campaigns

### DIFF
--- a/env-example
+++ b/env-example
@@ -6,6 +6,7 @@ LOCAL_ENV=true
 
 # prx api
 JINGLE_HOST=jingle.staging.prx.tech
+JINGLE_TTL=
 CMS_HOST=cms.staging.prx.tech
 CMS_TTL=
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -61,25 +61,16 @@ describe('AppComponent', () => {
     });
   }));
 
-  it('should create the app', async(() => {
+  it('should create the app', () => {
     expect(comp).toBeTruthy();
-  }));
-  //
-  // it(`should only show podcast choices when logged in`, async(() => {
-  //   comp.loggedIn = true;
-  //   fix.detectChanges();
-  //   expect(de.query(By.css('adflow-home'))).not.toBeNull();
-  //   comp.loggedIn = false;
-  //   fix.detectChanges();
-  //   expect(de.query(By.css('adflow-home'))).toBeNull();
-  // }));
+  });
 
-  it('should show user info when logged in', async(() => {
+  it('should show user info when logged in', () => {
     comp.loggedIn = true;
     fix.detectChanges();
     expect(de.query(By.css('prx-navuser'))).toBeTruthy();
     comp.loggedIn = false;
     fix.detectChanges();
     expect(de.query(By.css('prx-navuser'))).toBeNull();
-  }));
+  });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,7 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 
-import { CoreModule, CmsService, JingleService } from './core';
+import { CoreModule, CmsService } from './core';
 
 import { AuthModule, AuthService, ModalModule, MockHalService, MockHalDoc } from 'ngx-prx-styleguide';
 
@@ -50,9 +50,6 @@ describe('AppComponent', () => {
           setToken: token => cmsToken = token,
           account: new Subject<any>(),
           individualAccount: new Subject<any>()
-        }},
-        {provide: JingleService, useValue: {
-          campaigns: new Subject<any>()
         }}
       ]
     }).compileComponents().then(() => {
@@ -71,10 +68,10 @@ describe('AppComponent', () => {
   // it(`should only show podcast choices when logged in`, async(() => {
   //   comp.loggedIn = true;
   //   fix.detectChanges();
-  //   expect(de.query(By.css('adflow-podcasts'))).not.toBeNull();
+  //   expect(de.query(By.css('adflow-home'))).not.toBeNull();
   //   comp.loggedIn = false;
   //   fix.detectChanges();
-  //   expect(de.query(By.css('adflow-podcasts'))).toBeNull();
+  //   expect(de.query(By.css('adflow-home'))).toBeNull();
   // }));
 
   it('should show user info when logged in', async(() => {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,7 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 
-import { CoreModule, CmsService } from './core';
+import { CoreModule, CmsService, JingleService } from './core';
 
 import { AuthModule, AuthService, ModalModule, MockHalService, MockHalDoc } from 'ngx-prx-styleguide';
 
@@ -50,6 +50,9 @@ describe('AppComponent', () => {
           setToken: token => cmsToken = token,
           account: new Subject<any>(),
           individualAccount: new Subject<any>()
+        }},
+        {provide: JingleService, useValue: {
+          campaigns: new Subject<any>()
         }}
       ]
     }).compileComponents().then(() => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -21,7 +21,7 @@ export class AppComponent {
 
   constructor(
     private auth: AuthService,
-    private cms: CmsService,
+    private cms: CmsService
   ) {
     auth.token.subscribe((token) => {
       this.loadAccount(token);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { AuthService } from 'ngx-prx-styleguide';
-import { CmsService, HalDoc, JingleService } from './core';
+import { CmsService, HalDoc } from './core';
 import { Env } from './core/core.env';
 
 @Component({
@@ -22,11 +22,9 @@ export class AppComponent {
   constructor(
     private auth: AuthService,
     private cms: CmsService,
-    private jingle: JingleService
   ) {
     auth.token.subscribe((token) => {
       this.loadAccount(token);
-      this.loadCampaigns();
     });
   }
 
@@ -42,11 +40,5 @@ export class AppComponent {
       this.userImageDoc = null;
       this.userName = null;
     }
-  }
-
-  loadCampaigns() {
-    this.jingle.campaigns.subscribe(cDocs => {
-      // getting CORS error right now
-    })
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { AuthService } from 'ngx-prx-styleguide';
-import { CmsService, HalDoc } from './core';
+import { CmsService, HalDoc, JingleService } from './core';
 import { Env } from './core/core.env';
 
 @Component({
@@ -21,9 +21,13 @@ export class AppComponent {
 
   constructor(
     private auth: AuthService,
-    private cms: CmsService
+    private cms: CmsService,
+    private jingle: JingleService
   ) {
-    auth.token.subscribe(token => this.loadAccount(token));
+    auth.token.subscribe((token) => {
+      this.loadAccount(token);
+      this.loadCampaigns();
+    });
   }
 
   loadAccount(token: string) {
@@ -38,5 +42,11 @@ export class AppComponent {
       this.userImageDoc = null;
       this.userName = null;
     }
+  }
+
+  loadCampaigns() {
+    this.jingle.campaigns.subscribe(cDocs => {
+      // getting CORS error right now
+    })
   }
 }

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -2,7 +2,7 @@ import { ModuleWithProviders } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { AuthGuard, UnauthGuard } from 'ngx-prx-styleguide';
-import { HomeComponent, HomePodcastComponent } from './home';
+import { HomeComponent, HomePodcastComponent, HomeCampaignComponent } from './home';
 import { LoginComponent } from './login/login.component';
 
 export const routes: Routes = [
@@ -11,6 +11,7 @@ export const routes: Routes = [
 ];
 
 export const routingComponents: any[] = [
+  HomeCampaignComponent,
   HomeComponent,
   HomePodcastComponent,
   LoginComponent

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -2,7 +2,7 @@ import { ModuleWithProviders } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { AuthGuard, UnauthGuard } from 'ngx-prx-styleguide';
-import { HomeComponent } from './home';
+import { HomeComponent, HomePodcastComponent } from './home';
 import { LoginComponent } from './login/login.component';
 
 export const routes: Routes = [
@@ -12,6 +12,7 @@ export const routes: Routes = [
 
 export const routingComponents: any[] = [
   HomeComponent,
+  HomePodcastComponent,
   LoginComponent
 ];
 

--- a/src/app/core/core.env.ts
+++ b/src/app/core/core.env.ts
@@ -8,6 +8,7 @@ const DEFAULTS = {
   CMS_HOST: 'cms.prx.org',
   CMS_TTL: 1, // 1 second
   JINGLE_HOST: 'jingle.prx.org',
+  JINGLE_TTL: 1, // 1 second
   GA_KEY: ''
 };
 
@@ -34,5 +35,6 @@ export class Env {
   public static get CMS_HOST():              string { return getVar('CMS_HOST'); }
   public static get CMS_TTL():               number { return getVar('CMS_TTL'); }
   public static get JINGLE_HOST():           string { return getVar('JINGLE_HOST'); }
+  public static get JINGLE_TTL():            number { return getVar('JINGLE_TTL'); }
   public static get GA_KEY():                string { return getVar('GA_KEY'); }
 }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { HttpModule } from '@angular/http';
 import { FooterModule, HalModule, HeaderModule, ModalModule, ModalService } from 'ngx-prx-styleguide';
 
-import { CmsService } from './hal';
+import { CmsService, JingleService } from './hal';
 
 
 @NgModule({
@@ -20,7 +20,8 @@ import { CmsService } from './hal';
   ],
   providers: [
     CmsService,
-    ModalService
+    ModalService,
+    JingleService
   ]
 })
 

--- a/src/app/core/hal/cms.service.ts
+++ b/src/app/core/hal/cms.service.ts
@@ -17,7 +17,7 @@ export class CmsService extends HalBaseService {
     return Env.CMS_TTL;
   }
 
-  // pretty sure still need to get prx:authorization thru CMS 
+  // pretty sure still need to get prx:authorization thru CMS
   get auth(): HalObservable<HalDoc> {
     return this.follow('prx:authorization');
   }

--- a/src/app/core/hal/index.ts
+++ b/src/app/core/hal/index.ts
@@ -1,2 +1,3 @@
 export { CmsService } from './cms.service';
+export { JingleService } from './jingle.service';
 export { HalDoc, HalObservable } from 'ngx-prx-styleguide';

--- a/src/app/core/hal/jingle.service.ts
+++ b/src/app/core/hal/jingle.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { HalBaseService, HalDoc, HalObservable } from 'ngx-prx-styleguide';
+import { Env } from '../core.env';
+
+@Injectable()
+export class JingleService extends HalBaseService {
+
+  get host(): string {
+    return Env.JINGLE_HOST;
+  }
+
+  get path(): string {
+    return '/api/v1';
+  }
+
+  get ttl(): number {
+    return Env.JINGLE_TTL;
+  }
+
+  get campaigns(): HalObservable<HalDoc> {
+    return this.follow('prx:campaign');
+  }
+
+  // get defaultAccount(): HalObservable<HalDoc> {
+  //   return this.auth.follow('prx:default-account');
+  // }
+
+  // get individualAccount(): HalObservable<HalDoc> {
+  //   return <HalObservable<HalDoc>> this.auth.followItems('prx:accounts').map(accountDocs => {
+  //     return accountDocs.find(d => d['type'] === 'IndividualAccount');
+  //   });
+  // }
+
+  // get accounts(): HalObservable<HalDoc[]> {
+  //   return this.auth.followItems('prx:accounts');
+  // }
+  //
+}

--- a/src/app/core/hal/jingle.service.ts
+++ b/src/app/core/hal/jingle.service.ts
@@ -17,26 +17,7 @@ export class JingleService extends HalBaseService {
     return Env.JINGLE_TTL;
   }
 
-  get campaigns(): HalObservable<HalDoc[]> {
-    return this.followItems('prx:campaigns');
-  }
-
   get podcasts(): HalObservable<HalDoc[]> {
     return this.followItems('prx:podcasts');
   }
-
-  // get defaultAccount(): HalObservable<HalDoc> {
-  //   return this.auth.follow('prx:default-account');
-  // }
-
-  // get individualAccount(): HalObservable<HalDoc> {
-  //   return <HalObservable<HalDoc>> this.auth.followItems('prx:accounts').map(accountDocs => {
-  //     return accountDocs.find(d => d['type'] === 'IndividualAccount');
-  //   });
-  // }
-
-  // get accounts(): HalObservable<HalDoc[]> {
-  //   return this.auth.followItems('prx:accounts');
-  // }
-  //
 }

--- a/src/app/core/hal/jingle.service.ts
+++ b/src/app/core/hal/jingle.service.ts
@@ -17,8 +17,12 @@ export class JingleService extends HalBaseService {
     return Env.JINGLE_TTL;
   }
 
-  get campaigns(): HalObservable<HalDoc> {
-    return this.follow('prx:campaign');
+  get campaigns(): HalObservable<HalDoc[]> {
+    return this.followItems('prx:campaigns');
+  }
+
+  get podcasts(): HalObservable<HalDoc[]> {
+    return this.followItems('prx:podcasts');
   }
 
   // get defaultAccount(): HalObservable<HalDoc> {

--- a/src/app/core/index.ts
+++ b/src/app/core/index.ts
@@ -1,2 +1,2 @@
 export { CoreModule } from './core.module';
-export { CmsService, HalDoc } from './hal';
+export { CmsService, HalDoc, JingleService } from './hal';

--- a/src/app/home/directives/home-campaign.component.css
+++ b/src/app/home/directives/home-campaign.component.css
@@ -1,0 +1,67 @@
+h2 {
+  position: absolute;
+  bottom: 85px;
+  left: 0;
+  padding: 0 10px;
+  z-index: 11;
+  color: #fff;
+  max-height: 42px;
+  font-weight: 100;
+  font-size: 16px;
+  line-height: 21px;
+  overflow: hidden;
+  text-align: center;
+}
+h2 a {
+  color: inherit;
+}
+.run-dates {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  margin: 170px 0 0 0;
+  line-height: 18px;
+}
+.run-dates::before {
+  content: '';
+  display: block;
+  height: 71px;
+  position: absolute;
+  right: 0;
+  bottom: 50px;
+  top: 50px;
+  left: 0;
+  background-color: rgba(37,37,37,.7);
+}
+.status {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 3px 10px;
+  z-index: 10;
+  color: #fff;
+  background-color: #777;
+  font-weight: 400;
+  font-size: 11px;
+  text-transform: uppercase;
+  line-height: 18px;
+}
+.status.new {
+  background-color: #61A85D;
+}
+.status.draft {
+  background-color: #ffa500;
+}
+.status.running {
+  background-color: #368aa2;
+}
+.due {
+  position: absolute;
+  bottom: 31px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #ffa500;
+  font-weight: 700;
+  font-size: 16px;
+}

--- a/src/app/home/directives/home-campaign.component.spec.ts
+++ b/src/app/home/directives/home-campaign.component.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed, ComponentFixture, async } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Observable } from 'rxjs/Observable';
+
+import { MockHalDoc } from 'ngx-prx-styleguide';
+
+import { CoreModule } from './../../core';
+import { SharedModule } from './../../shared';
+import { HomeCampaignComponent } from './home-campaign.component';
+
+describe('HomeCampaignComponent', () => {
+  let comp: HomeCampaignComponent;
+  let fix: ComponentFixture<HomeCampaignComponent>;
+  let de: DebugElement;
+  let el: HTMLElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        HomeCampaignComponent
+      ],
+      imports: [
+        CoreModule,
+        RouterTestingModule,
+        SharedModule
+      ]
+    }).compileComponents().then(() => {
+      fix = TestBed.createComponent(HomeCampaignComponent);
+      comp = fix.componentInstance;
+      comp.campaign = new MockHalDoc({
+        start_date: new Date('11/30/2016'),
+        end_date: new Date('12/31/2016'),
+        approved: false
+      });
+      comp.sponsor = new MockHalDoc({name: 'Sponsor One'});
+      fix.detectChanges();
+      de = fix.debugElement;
+      el = de.nativeElement;
+    });
+  }));
+
+  it('should prominently show sponsor name', () => {
+    const h1 = de.query(By.css('h2')).query(By.css('a'));
+    expect(h1.nativeElement.textContent).toEqual('Sponsor One');
+  });
+
+  it('should show start, end, & due dates', () => {
+    const start= de.query(By.css('.start'));
+    expect(start.nativeElement.textContent).toEqual('11/30/16');
+    const end= de.query(By.css('.end'));
+    expect(end.nativeElement.textContent).toEqual('12/31/16');
+
+    // TODO we don't have due dates yet in jingle
+    const due= de.query(By.css('.due'));
+    expect(start.nativeElement.textContent).not.toBeNull();
+
+  })
+
+  it('should determine status of campaign from date and approval', () => {
+    expect(comp.statusText).toEqual('past');
+
+    const today = new Date();
+    comp.campaign['start_date'] = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 10);
+    comp.campaign['end_date'] = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 10);
+    comp.setStatus();
+    expect(comp.statusText).toEqual('running');
+
+    comp.campaign['start_date'] = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 10);
+    comp.setStatus();
+    expect(comp.statusText).toEqual('needs work');
+
+    comp.campaign['approved'] = true;
+    comp.setStatus();
+    expect(comp.statusText).toEqual('ready');
+  })
+});

--- a/src/app/home/directives/home-campaign.component.spec.ts
+++ b/src/app/home/directives/home-campaign.component.spec.ts
@@ -47,16 +47,15 @@ describe('HomeCampaignComponent', () => {
   });
 
   it('should show start, end, & due dates', () => {
-    const start= de.query(By.css('.start'));
+    const start = de.query(By.css('.start'));
     expect(start.nativeElement.textContent).toEqual('11/30/16');
-    const end= de.query(By.css('.end'));
+    const end = de.query(By.css('.end'));
     expect(end.nativeElement.textContent).toEqual('12/31/16');
 
     // TODO we don't have due dates yet in jingle
-    const due= de.query(By.css('.due'));
+    const due = de.query(By.css('.due'));
     expect(start.nativeElement.textContent).not.toBeNull();
-
-  })
+  });
 
   it('should determine status of campaign from date and approval', () => {
     expect(comp.statusText).toEqual('past');
@@ -74,5 +73,5 @@ describe('HomeCampaignComponent', () => {
     comp.campaign['approved'] = true;
     comp.setStatus();
     expect(comp.statusText).toEqual('ready');
-  })
+  });
 });

--- a/src/app/home/directives/home-campaign.component.spec.ts
+++ b/src/app/home/directives/home-campaign.component.spec.ts
@@ -51,8 +51,6 @@ describe('HomeCampaignComponent', () => {
     expect(start.nativeElement.textContent).toEqual('11/30/16');
     const end = de.query(By.css('.end'));
     expect(end.nativeElement.textContent).toEqual('12/31/16');
-
-    // TODO we don't have due dates yet in jingle
     const due = de.query(By.css('.due'));
     expect(start.nativeElement.textContent).not.toBeNull();
   });

--- a/src/app/home/directives/home-campaign.component.ts
+++ b/src/app/home/directives/home-campaign.component.ts
@@ -15,7 +15,7 @@ import { HalDoc } from '../../core';
         <p class="end">{{campaign.end_date | date:"MM/dd/yy"}}</p>
       </span>
       <p *ngIf="statusClass" [class]="statusClass">{{statusText}}</p>
-      <p *ngIf="dueDate" class="due">Due: {{dueDate | date:"MM/dd"}}</p>
+      <p *ngIf="dueDate" class="due">Due: {{dueDate | date: shortDate}}</p>
     </article>
   `
 })
@@ -23,6 +23,7 @@ import { HalDoc } from '../../core';
 export class HomeCampaignComponent implements OnInit {
 
   @Input() campaign: HalDoc;
+  editLink: string = '#'; // TODO make this real
   sponsor: HalDoc; //TODO should change to Sponsor Model
   statusText: string;
   statusClass: string;
@@ -35,9 +36,11 @@ export class HomeCampaignComponent implements OnInit {
   }
 
   loadSponsor() {
-    this.campaign.follow('prx:sponsor').subscribe(sponsor => {
-      this.sponsor = sponsor;
-    })
+    if (this.campaign && this.campaign.has('prx:sponsor')) {
+      this.campaign.follow('prx:sponsor').subscribe(sponsor => {
+        this.sponsor = sponsor;
+      })
+    }
   }
 
   setStatus() {

--- a/src/app/home/directives/home-campaign.component.ts
+++ b/src/app/home/directives/home-campaign.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core';
+import { HalDoc } from '../../core';
+
+@Component({
+  selector: 'adflow-home-campaign',
+  styleUrls: ['home-campaign.component.css'],
+  template: `
+  <h1>
+    {{campaign.start_date}}
+  </h1>
+  `
+})
+
+export class HomeCampaignComponent {
+
+  @Input() campaign: HalDoc;
+
+  campaigns: HalDoc[]; //TODO should change to Campaign Model
+
+}

--- a/src/app/home/directives/home-campaign.component.ts
+++ b/src/app/home/directives/home-campaign.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { HalDoc } from '../../core';
 
 @Component({
@@ -6,15 +6,24 @@ import { HalDoc } from '../../core';
   styleUrls: ['home-campaign.component.css'],
   template: `
   <h1>
-    {{campaign.start_date}}
+    {{sponsor.name}}
+    {{campaign.start_date}} - {{campaign.end_date}}
   </h1>
   `
 })
 
-export class HomeCampaignComponent {
+export class HomeCampaignComponent implements OnInit {
 
   @Input() campaign: HalDoc;
+  sponsor: HalDoc; //TODO should change to Sponsor Model
 
-  campaigns: HalDoc[]; //TODO should change to Campaign Model
+  ngOnInit() {
+    this.loadSponsor();
+  }
 
+  loadSponsor() {
+    this.campaign.follow('prx:sponsor').subscribe(sponsor => {
+      this.sponsor = sponsor;
+    })
+  }
 }

--- a/src/app/home/directives/home-campaign.component.ts
+++ b/src/app/home/directives/home-campaign.component.ts
@@ -23,8 +23,8 @@ import { HalDoc } from '../../core';
 export class HomeCampaignComponent implements OnInit {
 
   @Input() campaign: HalDoc;
-  editLink: string = '#'; // TODO make this real
-  sponsor: HalDoc; //TODO should change to Sponsor Model
+  editLink = '#'; // TODO make this real
+  sponsor: HalDoc; // TODO should change to Sponsor Model
   statusText: string;
   statusClass: string;
   dueDate: Date = new Date(); // TODO add due date to jingle campaigns
@@ -39,7 +39,7 @@ export class HomeCampaignComponent implements OnInit {
     if (this.campaign && this.campaign.has('prx:sponsor')) {
       this.campaign.follow('prx:sponsor').subscribe(sponsor => {
         this.sponsor = sponsor;
-      })
+      });
     }
   }
 
@@ -50,16 +50,16 @@ export class HomeCampaignComponent implements OnInit {
 
     // note, currently there is no 'approved' -- TODO add approval to jingle campaigns
     if (today < startDate && this.campaign['approved']) {
-      this.statusText = "ready"
+      this.statusText = 'ready';
       this.statusClass = 'status ready';
-    } else if (today < startDate && !this.campaign['approved']){
-      this.statusText = "needs work"
+    } else if (today < startDate && !this.campaign['approved']) {
+      this.statusText = 'needs work';
       this.statusClass = 'status draft';
     } else if (today > startDate && today > endDate) {
-      this.statusText = "past"
+      this.statusText = 'past';
       this.statusClass = 'status past';
     } else if (today > startDate && today < endDate) {
-      this.statusText = "running"
+      this.statusText = 'running';
       this.statusClass = 'status running';
     }
   }

--- a/src/app/home/directives/home-campaign.component.ts
+++ b/src/app/home/directives/home-campaign.component.ts
@@ -27,11 +27,11 @@ export class HomeCampaignComponent implements OnInit {
   sponsor: HalDoc; // TODO should change to Sponsor Model
   statusText: string;
   statusClass: string;
-  dueDate: Date = new Date(); // TODO add due date to jingle campaigns
+  dueDate: Date = new Date();
   // sponsorImageDoc: HalDoc; TODO get images for sponsors
 
   ngOnInit() {
-    this.loadSponsor(); // TODO could just have name in Jingle response? or do we want full sponsor here?
+    this.loadSponsor();
     this.setStatus();
   }
 
@@ -48,7 +48,6 @@ export class HomeCampaignComponent implements OnInit {
     const startDate = new Date(this.campaign['start_date']);
     const endDate = new Date(this.campaign['end_date']);
 
-    // note, currently there is no 'approved' -- TODO add approval to jingle campaigns
     if (today < startDate && this.campaign['approved']) {
       this.statusText = 'ready';
       this.statusClass = 'status ready';

--- a/src/app/home/directives/home-campaign.component.ts
+++ b/src/app/home/directives/home-campaign.component.ts
@@ -5,10 +5,18 @@ import { HalDoc } from '../../core';
   selector: 'adflow-home-campaign',
   styleUrls: ['home-campaign.component.css'],
   template: `
-  <h1>
-    {{sponsor.name}}
-    {{campaign.start_date}} - {{campaign.end_date}}
-  </h1>
+    <article *ngIf="campaign && sponsor">
+      <h2>
+        <a [routerLink]="editLink">{{sponsor.name}}</a>
+      </h2>
+      <span class="run-dates">
+        <p class="start">{{campaign.start_date | date:"MM/dd/yy"}}</p>
+        <p>to</p>
+        <p class="end">{{campaign.end_date | date:"MM/dd/yy"}}</p>
+      </span>
+      <p *ngIf="statusClass" [class]="statusClass">{{statusText}}</p>
+      <p *ngIf="dueDate" class="due">Due: {{dueDate | date:"MM/dd"}}</p>
+    </article>
   `
 })
 
@@ -16,14 +24,40 @@ export class HomeCampaignComponent implements OnInit {
 
   @Input() campaign: HalDoc;
   sponsor: HalDoc; //TODO should change to Sponsor Model
+  statusText: string;
+  statusClass: string;
+  dueDate: Date = new Date(); // TODO add due date to jingle campaigns
+  // sponsorImageDoc: HalDoc; TODO get images for sponsors
 
   ngOnInit() {
-    this.loadSponsor();
+    this.loadSponsor(); // TODO could just have name in Jingle response? or do we want full sponsor here?
+    this.setStatus();
   }
 
   loadSponsor() {
     this.campaign.follow('prx:sponsor').subscribe(sponsor => {
       this.sponsor = sponsor;
     })
+  }
+
+  setStatus() {
+    const today = new Date();
+    const startDate = new Date(this.campaign['start_date']);
+    const endDate = new Date(this.campaign['end_date']);
+
+    // note, currently there is no 'approved' -- TODO add to jingle
+    if (today < startDate && this.campaign['approved']) {
+      this.statusText = "ready"
+      this.statusClass = 'status ready';
+    } else if (today < startDate && !this.campaign['approved']){
+      this.statusText = "needs work"
+      this.statusClass = 'status draft';
+    } else if (today > startDate && today > endDate) {
+      this.statusText = "past"
+      this.statusClass = 'status past';
+    } else if (today > startDate && today < endDate) {
+      this.statusText = "running"
+      this.statusClass = 'status running';
+    }
   }
 }

--- a/src/app/home/directives/home-campaign.component.ts
+++ b/src/app/home/directives/home-campaign.component.ts
@@ -45,7 +45,7 @@ export class HomeCampaignComponent implements OnInit {
     const startDate = new Date(this.campaign['start_date']);
     const endDate = new Date(this.campaign['end_date']);
 
-    // note, currently there is no 'approved' -- TODO add to jingle
+    // note, currently there is no 'approved' -- TODO add approval to jingle campaigns
     if (today < startDate && this.campaign['approved']) {
       this.statusText = "ready"
       this.statusClass = 'status ready';

--- a/src/app/home/directives/home-podcast.component.css
+++ b/src/app/home/directives/home-podcast.component.css
@@ -1,0 +1,30 @@
+header {
+  position: relative;
+  overflow: auto;
+  width: 100%;
+  margin-bottom: 10px;
+}
+header h1 {
+  font-size: 30px;
+  line-height: 40px;
+  font-weight: 100;
+}
+
+.campaign-list {
+  display: flex;
+  justify-content: flex-start;
+  flex-flow: row wrap;
+  margin-left: -10px;
+}
+adflow-home-campaign {
+  display: block;
+  overflow: hidden;
+  position: relative;
+  margin-top: 10px;
+  margin-left: 10px;
+  flex-basis: 192px;
+  width: 192px;
+  height: 192px;
+  max-width: 192px;
+  background: #ddd;
+}

--- a/src/app/home/directives/home-podcast.component.spec.ts
+++ b/src/app/home/directives/home-podcast.component.spec.ts
@@ -39,15 +39,15 @@ describe('HomePodcastComponent', () => {
   }));
 
   it('should prominently show podcast name', () => {
-    let h1 = de.query(By.css('h1')).query(By.css('a'));
+    const h1 = de.query(By.css('h1')).query(By.css('a'));
     expect(h1.nativeElement.textContent).toEqual('Podcast One');
   });
 
   it('should show campaigns for podcast', () => {
     expect(de.query(By.css('adflow-home-campaign'))).toBeNull();
-    let campaign1 = new MockHalDoc({name: 'one'});
+    const campaign1 = new MockHalDoc({name: 'one'});
     comp.campaigns = [campaign1];
     fix.detectChanges();
     expect(de.query(By.css('adflow-home-campaign'))).not.toBeNull();
-  })
+  });
 });

--- a/src/app/home/directives/home-podcast.component.spec.ts
+++ b/src/app/home/directives/home-podcast.component.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed, ComponentFixture, async } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Observable } from 'rxjs/Observable';
+
+import { MockHalDoc } from 'ngx-prx-styleguide';
+
+import { CoreModule } from './../../core';
+import { SharedModule } from './../../shared';
+import { HomePodcastComponent } from './home-podcast.component';
+import { HomeCampaignComponent } from './home-campaign.component';
+
+describe('HomePodcastComponent', () => {
+  let comp: HomePodcastComponent;
+  let fix: ComponentFixture<HomePodcastComponent>;
+  let de: DebugElement;
+  let el: HTMLElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        HomeCampaignComponent,
+        HomePodcastComponent
+      ],
+      imports: [
+        CoreModule,
+        RouterTestingModule,
+        SharedModule
+      ]
+    }).compileComponents().then(() => {
+      fix = TestBed.createComponent(HomePodcastComponent);
+      comp = fix.componentInstance;
+      comp.podcast = new MockHalDoc({name: 'Podcast One'});
+      fix.detectChanges();
+      de = fix.debugElement;
+      el = de.nativeElement;
+    });
+  }));
+
+  it('should prominently show podcast name', () => {
+    let h1 = de.query(By.css('h1')).query(By.css('a'));
+    expect(h1.nativeElement.textContent).toEqual('Podcast One');
+  });
+
+  it('should show campaigns for podcast', () => {
+    expect(de.query(By.css('adflow-home-campaign'))).toBeNull();
+    let campaign1 = new MockHalDoc({name: 'one'});
+    comp.campaigns = [campaign1];
+    fix.detectChanges();
+    expect(de.query(By.css('adflow-home-campaign'))).not.toBeNull();
+  })
+});

--- a/src/app/home/directives/home-podcast.component.ts
+++ b/src/app/home/directives/home-podcast.component.ts
@@ -8,7 +8,7 @@ import { HalDoc } from '../../core';
   <header>
     <h1><a href="#">{{podcast.name}}</a></h1>
   </header>
-  <div class="campaign-list">
+  <div class="campaign-list" *ngIf="campaigns && campaigns.length">
     <adflow-home-campaign *ngFor="let c of campaigns" [campaign]="c"></adflow-home-campaign>
   </div>
   `
@@ -25,8 +25,9 @@ export class HomePodcastComponent implements OnInit {
   }
 
   loadCampaigns() {
-    this.podcast.followItems('prx:campaigns').subscribe(campaigns => {
-      this.campaigns = campaigns;
-    });
+    console.log(this.podcast);
+    // this.podcast.followItems('prx:campaigns').subscribe(campaigns => {
+    //   this.campaigns = campaigns;
+    // });
   }
 }

--- a/src/app/home/directives/home-podcast.component.ts
+++ b/src/app/home/directives/home-podcast.component.ts
@@ -5,10 +5,12 @@ import { HalDoc } from '../../core';
   selector: 'adflow-home-podcast',
   styleUrls: ['home-podcast.component.css'],
   template: `
-  <h1>
-    {{podcast.name}}
-  </h1>
-  <adflow-home-campaign *ngFor="let c of campaigns" [campaign]="c"></adflow-home-campaign>
+  <header>
+    <h1><a href="#">{{podcast.name}}</a></h1>
+  </header>
+  <div class="campaign-list">
+    <adflow-home-campaign *ngFor="let c of campaigns" [campaign]="c"></adflow-home-campaign>
+  </div>
   `
 })
 

--- a/src/app/home/directives/home-podcast.component.ts
+++ b/src/app/home/directives/home-podcast.component.ts
@@ -25,9 +25,10 @@ export class HomePodcastComponent implements OnInit {
   }
 
   loadCampaigns() {
-    console.log(this.podcast);
-    // this.podcast.followItems('prx:campaigns').subscribe(campaigns => {
-    //   this.campaigns = campaigns;
-    // });
+    if (this.podcast && this.podcast.has('prx:campaigns')) {
+      this.podcast.followItems('prx:campaigns').subscribe(campaigns => {
+        this.campaigns = campaigns;
+      });
+    }
   }
 }

--- a/src/app/home/directives/home-podcast.component.ts
+++ b/src/app/home/directives/home-podcast.component.ts
@@ -1,16 +1,30 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { HalDoc } from '../../core';
 
 @Component({
   selector: 'adflow-home-podcast',
   styleUrls: ['home-podcast.component.css'],
-  template: `<h1>{{podcast.name}}</h1>`
+  template: `
+  <h1>
+    {{podcast.name}}
+  </h1>
+  <adflow-home-campaign *ngFor="let c of campaigns" [campaign]="c"></adflow-home-campaign>
+  `
 })
 
-export class HomePodcastComponent {
+export class HomePodcastComponent implements OnInit {
 
   @Input() podcast: HalDoc;
 
   campaigns: HalDoc[]; //TODO should change to Campaign Model
 
+  ngOnInit() {
+    this.loadCampaigns();
+  }
+
+  loadCampaigns() {
+    this.podcast.followItems('prx:campaigns').subscribe(campaigns => {
+      this.campaigns = campaigns;
+    });
+  }
 }

--- a/src/app/home/directives/home-podcast.component.ts
+++ b/src/app/home/directives/home-podcast.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+import { HalDoc } from '../../core';
+
+@Component({
+  selector: 'adflow-home-podcast',
+  styleUrls: ['home-podcast.component.css'],
+  template: `<h1>{{podcast.name}}</h1>`
+})
+
+export class HomePodcastComponent {
+
+  @Input() podcast: HalDoc;
+
+  campaigns: HalDoc[]; //TODO should change to Campaign Model
+
+}

--- a/src/app/home/directives/home-podcast.component.ts
+++ b/src/app/home/directives/home-podcast.component.ts
@@ -18,7 +18,7 @@ export class HomePodcastComponent implements OnInit {
 
   @Input() podcast: HalDoc;
 
-  campaigns: HalDoc[]; //TODO should change to Campaign Model
+  campaigns: HalDoc[]; // TODO should change to Campaign Model
 
   ngOnInit() {
     this.loadCampaigns();

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,0 +1,16 @@
+section {
+  padding: 40px 0;
+  min-height: 340px;
+}
+header h2 {
+  font-size: 25px;
+  font-weight: 600;
+  line-height: 30px;
+  color: #368aa2;
+  flex: 1;
+}
+
+adflow-home-podcast {
+  display: block;
+  margin-bottom: 40px;
+}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -5,7 +5,7 @@
     </header>
     <hr>
     <prx-spinner *ngIf="!isLoaded"></prx-spinner>
-    <div *ngIf="podcasts">
+    <div *ngIf="podcasts && podcasts.length">
       <adflow-home-podcast *ngFor="let p of podcasts" [podcast]="p"></adflow-home-podcast>
     </div>
   </section>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,0 +1,11 @@
+<div class="main">
+  <section>
+    <header>
+      <h2>Your Podcasts</h2>
+    </header>
+    <prx-spinner *ngIf="!isLoaded"></prx-spinner>
+    <div *ngIf="podcasts">
+      <adflow-home-podcast *ngFor="let p of podcasts" [podcast]="p"></adflow-home-podcast>
+    </div>
+  </section>
+</div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,8 +1,9 @@
 <div class="main">
   <section>
     <header>
-      <h2>Your Podcasts</h2>
+      <h2>Current & Upcoming Sponsorship Campaigns</h2>
     </header>
+    <hr>
     <prx-spinner *ngIf="!isLoaded"></prx-spinner>
     <div *ngIf="podcasts">
       <adflow-home-podcast *ngFor="let p of podcasts" [podcast]="p"></adflow-home-podcast>

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -54,10 +54,10 @@ describe('HomeComponent', () => {
   });
 
   it('should show podcasts', () => {
+    expect(de.query(By.css('adflow-home-podcast'))).toBeNull();
     let podcast1 = new MockHalDoc({name: 'one'});
     comp.podcasts = [podcast1];
     fix.detectChanges();
-    console.log(comp);
     expect(de.query(By.css('adflow-home-podcast'))).not.toBeNull();
   })
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -55,9 +55,9 @@ describe('HomeComponent', () => {
 
   it('should show podcasts', () => {
     expect(de.query(By.css('adflow-home-podcast'))).toBeNull();
-    let podcast1 = new MockHalDoc({name: 'one'});
+    const podcast1 = new MockHalDoc({name: 'one'});
     comp.podcasts = [podcast1];
     fix.detectChanges();
     expect(de.query(By.css('adflow-home-podcast'))).not.toBeNull();
-  })
+  });
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -2,10 +2,9 @@ import { TestBed, ComponentFixture, async } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 
-import { MockHalService, MockHalDoc } from 'ngx-prx-styleguide';
+import { MockHalDoc } from 'ngx-prx-styleguide';
 
 import { CoreModule, JingleService } from './../core';
 import { SharedModule } from './../shared';

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed, ComponentFixture, async } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Subject } from 'rxjs/Subject';
+import { Observable } from 'rxjs/Observable';
+
+import { MockHalService, MockHalDoc } from 'ngx-prx-styleguide';
+
+import { CoreModule, JingleService } from './../core';
+import { SharedModule } from './../shared';
+import { HomeComponent } from './home.component';
+import { HomePodcastComponent } from './directives/home-podcast.component';
+import { HomeCampaignComponent } from './directives/home-campaign.component';
+
+describe('HomeComponent', () => {
+  let comp: HomeComponent;
+  let fix: ComponentFixture<HomeComponent>;
+  let de: DebugElement;
+  let el: HTMLElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        HomeCampaignComponent,
+        HomeComponent,
+        HomePodcastComponent
+      ],
+      imports: [
+        CoreModule,
+        RouterTestingModule,
+        SharedModule
+      ],
+      providers: [
+        {provide: JingleService, useValue: {
+          podcasts: Observable.of([])
+        }}
+      ]
+    }).compileComponents().then(() => {
+      fix = TestBed.createComponent(HomeComponent);
+      comp = fix.componentInstance;
+      fix.detectChanges();
+      de = fix.debugElement;
+      el = de.nativeElement;
+    });
+  }));
+
+
+  it('should show spinner before loads', () => {
+    expect(de.query(By.css('prx-spinner'))).toBeFalsy();
+
+    comp.isLoaded = false;
+    fix.detectChanges();
+    expect(de.query(By.css('prx-spinner'))).not.toBeNull();
+  });
+
+  it('should show podcasts', () => {
+    let podcast1 = new MockHalDoc({name: 'one'});
+    comp.podcasts = [podcast1];
+    fix.detectChanges();
+    console.log(comp);
+    expect(de.query(By.css('adflow-home-podcast'))).not.toBeNull();
+  })
+});

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,11 +1,25 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { JingleService, HalDoc } from '../core';
 
 @Component({
   selector: 'adflow-home',
-  template: `<h1>Adflow: home</h1>
-  `
+  styleUrls: ['home.component.css'],
+  templateUrl: 'home.component.html'
 })
-export class HomeComponent {
-  // eventually this will have Tabs+TabService (or whatever else we use because Tab uses BaseModel plus we have mobile requirements),
-  //  but right now it does nothing but a place to point the router 
+
+export class HomeComponent implements OnInit {
+
+  isLoaded = false;
+  podcasts: HalDoc[];
+
+  constructor(private jingle: JingleService) {}
+
+  ngOnInit() {
+    this.isLoaded = false;
+    this.jingle.podcasts.subscribe(podcasts => {
+      this.isLoaded = true;
+      this.podcasts = podcasts;
+    });
+  }
+
 }

--- a/src/app/home/index.ts
+++ b/src/app/home/index.ts
@@ -1,2 +1,3 @@
 export * from './home.component';
 export * from './directives/home-podcast.component';
+export * from './directives/home-campaign.component';

--- a/src/app/home/index.ts
+++ b/src/app/home/index.ts
@@ -1,1 +1,2 @@
-export { HomeComponent } from './home.component';
+export * from './home.component';
+export * from './directives/home-podcast.component';


### PR DESCRIPTION
#9 Have a dashboard homepage listing podcasts & the campaigns for each podcast. Right now, this shows everything in the db; eventually, this could be an admin only page, or this could become filtered by the user's podcast and the admin page could be something separate. 
Potentially helpful:

- [Here's](https://projects.invisionapp.com/share/UTBZ5DD7F#/screens/236772613) the original wireframe for the dashboard
- [Here's](https://docs.google.com/forms/d/e/1FAIpQLSeSV6ILDnKl0DrDb-5-E7_kUSqs7SUOvL2FhRGpRI0j5uwmyA/viewform?usp=sf_link) the google form to add new campaigns (and, optionally, new sponsors and/or new podcasts)