### PR TITLE
Add models from Styleguide

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "fs": "0.0.1-security",
     "morgan": "^1.9.0",
     "newrelic": "^2.3.1",
-    "ngx-prx-styleguide": "^0.0.19",
+    "ngx-prx-styleguide": "^0.0.20",
     "pug": "^2.0.0-rc.4",
     "rxjs": "^5.4.2",
     "zone.js": "^0.8.14"

--- a/src/app/home/directives/home-campaign.component.spec.ts
+++ b/src/app/home/directives/home-campaign.component.spec.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs/Observable';
 import { MockHalDoc } from 'ngx-prx-styleguide';
 
 import { CoreModule } from './../../core';
-import { SharedModule, CampaignModel } from './../../shared';
+import { SharedModule, CampaignModel, SponsorModel } from './../../shared';
 import { HomeCampaignComponent } from './home-campaign.component';
 
 describe('HomeCampaignComponent', () => {
@@ -34,7 +34,7 @@ describe('HomeCampaignComponent', () => {
         end_date: new Date('12/31/2016'),
         approved: false
       }));
-      comp.campaign.sponsor = new MockHalDoc({name: 'Sponsor One'});
+      comp.campaign.sponsor = new SponsorModel(new MockHalDoc({name: 'Sponsor One'}));
       fix.detectChanges();
       de = fix.debugElement;
       el = de.nativeElement;

--- a/src/app/home/directives/home-campaign.component.spec.ts
+++ b/src/app/home/directives/home-campaign.component.spec.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs/Observable';
 import { MockHalDoc } from 'ngx-prx-styleguide';
 
 import { CoreModule } from './../../core';
-import { SharedModule } from './../../shared';
+import { SharedModule, CampaignModel } from './../../shared';
 import { HomeCampaignComponent } from './home-campaign.component';
 
 describe('HomeCampaignComponent', () => {
@@ -29,12 +29,12 @@ describe('HomeCampaignComponent', () => {
     }).compileComponents().then(() => {
       fix = TestBed.createComponent(HomeCampaignComponent);
       comp = fix.componentInstance;
-      comp.campaign = new MockHalDoc({
+      comp.campaign = new CampaignModel(null, new MockHalDoc({
         start_date: new Date('11/30/2016'),
         end_date: new Date('12/31/2016'),
         approved: false
-      });
-      comp.sponsor = new MockHalDoc({name: 'Sponsor One'});
+      }));
+      comp.campaign.sponsor = new MockHalDoc({name: 'Sponsor One'});
       fix.detectChanges();
       de = fix.debugElement;
       el = de.nativeElement;
@@ -59,16 +59,16 @@ describe('HomeCampaignComponent', () => {
     expect(comp.statusText).toEqual('past');
 
     const today = new Date();
-    comp.campaign['start_date'] = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 10);
-    comp.campaign['end_date'] = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 10);
+    comp.campaign.startDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 10);
+    comp.campaign.endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 10);
     comp.setStatus();
     expect(comp.statusText).toEqual('running');
 
-    comp.campaign['start_date'] = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 10);
+    comp.campaign.startDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 10);
     comp.setStatus();
     expect(comp.statusText).toEqual('needs work');
 
-    comp.campaign['approved'] = true;
+    comp.campaign.approved = true;
     comp.setStatus();
     expect(comp.statusText).toEqual('ready');
   });

--- a/src/app/home/directives/home-campaign.component.spec.ts
+++ b/src/app/home/directives/home-campaign.component.spec.ts
@@ -30,8 +30,8 @@ describe('HomeCampaignComponent', () => {
       fix = TestBed.createComponent(HomeCampaignComponent);
       comp = fix.componentInstance;
       comp.campaign = new CampaignModel(null, new MockHalDoc({
-        start_date: new Date('11/30/2016'),
-        end_date: new Date('12/31/2016'),
+        startDate: new Date('11/30/2016'),
+        endDate: new Date('12/31/2016'),
         approved: false
       }));
       comp.campaign.sponsor = new SponsorModel(new MockHalDoc({name: 'Sponsor One'}));

--- a/src/app/home/directives/home-campaign.component.ts
+++ b/src/app/home/directives/home-campaign.component.ts
@@ -1,57 +1,49 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { HalDoc } from '../../core';
+import { CampaignModel } from '../../shared';
+
 
 @Component({
   selector: 'adflow-home-campaign',
   styleUrls: ['home-campaign.component.css'],
   template: `
-    <article *ngIf="campaign && sponsor">
+    <article *ngIf="campaign && campaign.sponsor">
       <h2>
-        <a [routerLink]="editLink">{{sponsor.name}}</a>
+        <a [routerLink]="editLink">{{campaign.sponsor.name}}</a>
       </h2>
       <span class="run-dates">
-        <p class="start">{{campaign.start_date | date:"MM/dd/yy"}}</p>
+        <p class="start">{{campaign.startDate | date:"MM/dd/yy"}}</p>
         <p>to</p>
-        <p class="end">{{campaign.end_date | date:"MM/dd/yy"}}</p>
+        <p class="end">{{campaign.endDate | date:"MM/dd/yy"}}</p>
       </span>
       <p *ngIf="statusClass" [class]="statusClass">{{statusText}}</p>
-      <p *ngIf="dueDate" class="due">Due: {{dueDate | date: shortDate}}</p>
+      <p *ngIf="campaign.dueDate" class="due">Due: {{campaign.dueDate | date: shortDate}}</p>
     </article>
   `
 })
 
 export class HomeCampaignComponent implements OnInit {
 
-  @Input() campaign: HalDoc;
+  @Input() campaign: CampaignModel;
   editLink = '#'; // TODO make this real
   sponsor: HalDoc; // TODO should change to Sponsor Model
   statusText: string;
   statusClass: string;
-  dueDate: Date = new Date();
   // sponsorImageDoc: HalDoc; TODO get images for sponsors
 
   ngOnInit() {
-    this.loadSponsor();
     this.setStatus();
-  }
-
-  loadSponsor() {
-    if (this.campaign && this.campaign.has('prx:sponsor')) {
-      this.campaign.follow('prx:sponsor').subscribe(sponsor => {
-        this.sponsor = sponsor;
-      });
-    }
   }
 
   setStatus() {
     const today = new Date();
-    const startDate = new Date(this.campaign['start_date']);
-    const endDate = new Date(this.campaign['end_date']);
+    const startDate = new Date(this.campaign.startDate);
+    const endDate = new Date(this.campaign.endDate);
 
-    if (today < startDate && this.campaign['approved']) {
+    if (today < startDate && this.campaign.approved) {
       this.statusText = 'ready';
       this.statusClass = 'status ready';
-    } else if (today < startDate && !this.campaign['approved']) {
+    } else if (today < startDate && !this.campaign.approved) {
       this.statusText = 'needs work';
       this.statusClass = 'status draft';
     } else if (today > startDate && today > endDate) {

--- a/src/app/home/directives/home-podcast.component.spec.ts
+++ b/src/app/home/directives/home-podcast.component.spec.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs/Observable';
 import { MockHalDoc } from 'ngx-prx-styleguide';
 
 import { CoreModule } from './../../core';
-import { SharedModule, PodcastModel } from './../../shared';
+import { SharedModule, PodcastModel, CampaignModel } from './../../shared';
 import { HomePodcastComponent } from './home-podcast.component';
 import { HomeCampaignComponent } from './home-campaign.component';
 
@@ -45,7 +45,7 @@ describe('HomePodcastComponent', () => {
 
   it('should show campaigns for podcast', () => {
     expect(de.query(By.css('adflow-home-campaign'))).toBeNull();
-    const campaign1 = new MockHalDoc({name: 'one'});
+    const campaign1 = new CampaignModel(comp.podcast.doc, new MockHalDoc({name: 'one'}));
     comp.podcast.campaigns = [campaign1];
     fix.detectChanges();
     expect(de.query(By.css('adflow-home-campaign'))).not.toBeNull();

--- a/src/app/home/directives/home-podcast.component.spec.ts
+++ b/src/app/home/directives/home-podcast.component.spec.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs/Observable';
 import { MockHalDoc } from 'ngx-prx-styleguide';
 
 import { CoreModule } from './../../core';
-import { SharedModule } from './../../shared';
+import { SharedModule, PodcastModel } from './../../shared';
 import { HomePodcastComponent } from './home-podcast.component';
 import { HomeCampaignComponent } from './home-campaign.component';
 
@@ -31,7 +31,7 @@ describe('HomePodcastComponent', () => {
     }).compileComponents().then(() => {
       fix = TestBed.createComponent(HomePodcastComponent);
       comp = fix.componentInstance;
-      comp.podcast = new MockHalDoc({name: 'Podcast One'});
+      comp.podcast = new PodcastModel(new MockHalDoc({name: 'Podcast One'}));
       fix.detectChanges();
       de = fix.debugElement;
       el = de.nativeElement;
@@ -46,7 +46,7 @@ describe('HomePodcastComponent', () => {
   it('should show campaigns for podcast', () => {
     expect(de.query(By.css('adflow-home-campaign'))).toBeNull();
     const campaign1 = new MockHalDoc({name: 'one'});
-    comp.campaigns = [campaign1];
+    comp.podcast.campaigns = [campaign1];
     fix.detectChanges();
     expect(de.query(By.css('adflow-home-campaign'))).not.toBeNull();
   });

--- a/src/app/home/directives/home-podcast.component.ts
+++ b/src/app/home/directives/home-podcast.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { PodcastModel } from '../../shared'; // CampaignModel too
+import { PodcastModel } from '../../shared';
 
 @Component({
   selector: 'adflow-home-podcast',
@@ -15,7 +15,5 @@ import { PodcastModel } from '../../shared'; // CampaignModel too
 })
 
 export class HomePodcastComponent {
-
   @Input() podcast: PodcastModel;
-
 }

--- a/src/app/home/directives/home-podcast.component.ts
+++ b/src/app/home/directives/home-podcast.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { HalDoc } from '../../core';
+import { PodcastModel } from '../../shared'; // CampaignModel too
 
 @Component({
   selector: 'adflow-home-podcast',
@@ -8,27 +9,30 @@ import { HalDoc } from '../../core';
   <header>
     <h1><a href="#">{{podcast.name}}</a></h1>
   </header>
-  <div class="campaign-list" *ngIf="campaigns && campaigns.length">
-    <adflow-home-campaign *ngFor="let c of campaigns" [campaign]="c"></adflow-home-campaign>
+  <div class="campaign-list" *ngIf="podcast.campaigns && podcast.campaigns.length">
+    <adflow-home-campaign *ngFor="let c of podcast.campaigns" [campaign]="c"></adflow-home-campaign>
   </div>
   `
 })
 
-export class HomePodcastComponent implements OnInit {
+export class HomePodcastComponent { //implements OnInit {
 
-  @Input() podcast: HalDoc;
+  @Input() podcast: PodcastModel;
 
-  campaigns: HalDoc[]; // TODO should change to Campaign Model
+  // we should be able to get this all from podcast.campaigns once PodcastModel related() is working
+  //campaigns: HalDoc[]; // TODO should change to Campaign Model
 
-  ngOnInit() {
-    this.loadCampaigns();
-  }
+  // ngOnInit() {
+  //   console.log(' in home podcast oninit')
+  //   // this.loadCampaigns();
+  // }
 
-  loadCampaigns() {
-    if (this.podcast && this.podcast.has('prx:campaigns')) {
-      this.podcast.followItems('prx:campaigns').subscribe(campaigns => {
-        this.campaigns = campaigns;
-      });
-    }
-  }
+  // loadCampaigns() {
+  //   // follow doc
+  //   if (this.podcast.doc && this.podcast.doc.has('prx:campaigns')) {
+  //     this.podcast.doc.followItems('prx:campaigns').subscribe(campaigns => {
+  //       this.campaigns = campaigns;
+  //     });
+  //   }
+  // }
 }

--- a/src/app/home/directives/home-podcast.component.ts
+++ b/src/app/home/directives/home-podcast.component.ts
@@ -1,5 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { HalDoc } from '../../core';
+import { Component, Input } from '@angular/core';
 import { PodcastModel } from '../../shared'; // CampaignModel too
 
 @Component({
@@ -15,24 +14,8 @@ import { PodcastModel } from '../../shared'; // CampaignModel too
   `
 })
 
-export class HomePodcastComponent { //implements OnInit {
+export class HomePodcastComponent {
 
   @Input() podcast: PodcastModel;
 
-  // we should be able to get this all from podcast.campaigns once PodcastModel related() is working
-  //campaigns: HalDoc[]; // TODO should change to Campaign Model
-
-  // ngOnInit() {
-  //   console.log(' in home podcast oninit')
-  //   // this.loadCampaigns();
-  // }
-
-  // loadCampaigns() {
-  //   // follow doc
-  //   if (this.podcast.doc && this.podcast.doc.has('prx:campaigns')) {
-  //     this.podcast.doc.followItems('prx:campaigns').subscribe(campaigns => {
-  //       this.campaigns = campaigns;
-  //     });
-  //   }
-  // }
 }

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -55,7 +55,7 @@ describe('HomeComponent', () => {
 
   it('should show podcasts', () => {
     expect(de.query(By.css('adflow-home-podcast'))).toBeNull();
-    const podDoc = new MockHalDoc({name: 'one'})
+    const podDoc = new MockHalDoc({name: 'one'});
     const podcast1 = new PodcastModel(podDoc);
     comp.podcasts = [podcast1];
     fix.detectChanges();

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs/Observable';
 import { MockHalDoc } from 'ngx-prx-styleguide';
 
 import { CoreModule, JingleService } from './../core';
-import { SharedModule } from './../shared';
+import { SharedModule, PodcastModel } from './../shared';
 import { HomeComponent } from './home.component';
 import { HomePodcastComponent } from './directives/home-podcast.component';
 import { HomeCampaignComponent } from './directives/home-campaign.component';
@@ -55,7 +55,8 @@ describe('HomeComponent', () => {
 
   it('should show podcasts', () => {
     expect(de.query(By.css('adflow-home-podcast'))).toBeNull();
-    const podcast1 = new MockHalDoc({name: 'one'});
+    const podDoc = new MockHalDoc({name: 'one'})
+    const podcast1 = new PodcastModel(podDoc);
     comp.podcasts = [podcast1];
     fix.detectChanges();
     expect(de.query(By.css('adflow-home-podcast'))).not.toBeNull();

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { JingleService, HalDoc } from '../core';
+import { JingleService } from '../core';
 import { PodcastModel } from '../shared';
 
 @Component({

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -19,7 +19,7 @@ export class HomeComponent implements OnInit {
     this.isLoaded = false;
     this.jingle.podcasts.subscribe(pDocs => {
       this.isLoaded = true;
-      this.podcasts = pDocs.map((p) => new PodcastModel(p ,false)); // TODO why does flipping this to true make podcasts not show up?
+      this.podcasts = pDocs.map((p) => new PodcastModel(p));
     });
   }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { JingleService, HalDoc } from '../core';
+import { PodcastModel } from '../shared';
 
 @Component({
   selector: 'adflow-home',
@@ -10,15 +11,15 @@ import { JingleService, HalDoc } from '../core';
 export class HomeComponent implements OnInit {
 
   isLoaded = false;
-  podcasts: HalDoc[];
+  podcasts: PodcastModel[];
 
   constructor(private jingle: JingleService) {}
 
   ngOnInit() {
     this.isLoaded = false;
-    this.jingle.podcasts.subscribe(podcasts => {
+    this.jingle.podcasts.subscribe(pDocs => {
       this.isLoaded = true;
-      this.podcasts = podcasts;
+      this.podcasts = pDocs.map((p) => new PodcastModel(p ,false)); // TODO why does flipping this to true make podcasts not show up?
     });
   }
 

--- a/src/app/shared/index.ts
+++ b/src/app/shared/index.ts
@@ -1,1 +1,2 @@
 export * from './shared.module';
+export * from './model';

--- a/src/app/shared/model/campaign.model.spec.ts
+++ b/src/app/shared/model/campaign.model.spec.ts
@@ -1,0 +1,30 @@
+import { Observable } from 'rxjs/Observable';
+import { MockHalDoc } from 'ngx-prx-styleguide';
+import { CampaignModel } from './campaign.model';
+
+describe('CampaignModel', () => {
+
+  const makeCampaign = (data?: any, extra: any = {} ) => {
+    const cDoc = new MockHalDoc(data);
+    cDoc.mock('prx:sponsor', extra.sponsor || {});
+    return new CampaignModel(null, cDoc);
+  }
+
+  it('loads data from the haldoc', () => {
+    let campaign = makeCampaign({copy: 'Say hello to world'});
+    expect(campaign.copy).toEqual('Say hello to world');
+    expect(campaign.isNew).toBeFalsy();
+  });
+
+  it('uses the campaign id for the key', () => {
+    expect(makeCampaign({id: 'campaign-id'}).key()).toContain('.campaign-id');
+  });
+
+  it('loads related sponsor', () => {
+    let sponsor = {name: 'sponsor-one'};;
+    let campaign = makeCampaign({name: 'foo'}, {sponsor: sponsor});
+    expect(campaign.sponsor['name']).toEqual('sponsor-one');
+  });
+
+
+});

--- a/src/app/shared/model/campaign.model.spec.ts
+++ b/src/app/shared/model/campaign.model.spec.ts
@@ -8,10 +8,10 @@ describe('CampaignModel', () => {
     const cDoc = new MockHalDoc(data);
     cDoc.mock('prx:sponsor', extra.sponsor || {});
     return new CampaignModel(null, cDoc);
-  }
+  };
 
   it('loads data from the haldoc', () => {
-    let campaign = makeCampaign({copy: 'Say hello to world'});
+    const campaign = makeCampaign({copy: 'Say hello to world'});
     expect(campaign.copy).toEqual('Say hello to world');
     expect(campaign.isNew).toBeFalsy();
   });
@@ -21,10 +21,9 @@ describe('CampaignModel', () => {
   });
 
   it('loads related sponsor', () => {
-    let sponsor = {name: 'sponsor-one'};;
-    let campaign = makeCampaign({name: 'foo'}, {sponsor: sponsor});
+    const sponsor = {name: 'sponsor-one'};
+    const campaign = makeCampaign({name: 'foo'}, {sponsor: sponsor});
     expect(campaign.sponsor['name']).toEqual('sponsor-one');
   });
-
 
 });

--- a/src/app/shared/model/campaign.model.ts
+++ b/src/app/shared/model/campaign.model.ts
@@ -37,11 +37,11 @@ export class CampaignModel extends BaseModel {
 
   decode(): void {
     this.id = this.doc['id'];
-    this.startDate = new Date(this.doc['start_date']);
-    this.endDate = new Date(this.doc['end_date']);
+    this.startDate = new Date(this.doc['startDate']);
+    this.endDate = new Date(this.doc['endDate']);
     this.copy = this.doc['copy'];
     this.zone = this.doc['zone'];
-    this.dueDate = this.doc['due_date'] ? new Date(this.doc['due_date']) : new Date(); // TODO add due date to campaigns
+    this.dueDate = this.doc['dueDate'] ? new Date(this.doc['dueDate']) : new Date(); // TODO add due date to campaigns
     this.approved = this.doc['approved']; // TODO add approved to campaigns
   }
 

--- a/src/app/shared/model/campaign.model.ts
+++ b/src/app/shared/model/campaign.model.ts
@@ -1,6 +1,6 @@
 import { BaseModel, HalDoc } from 'ngx-prx-styleguide';
 import { Observable } from 'rxjs/Observable';
-import { SponsorModel } from './sponsor.model'
+import { SponsorModel } from './sponsor.model';
 
 export class CampaignModel extends BaseModel {
   public id: number;
@@ -12,7 +12,7 @@ export class CampaignModel extends BaseModel {
   public approved = false;
   public sponsor: SponsorModel;
 
-  SETABLE = ['copy'];
+  SETABLE = ['copy', 'approved'];
 
   VALIDATORS = {};
 
@@ -53,6 +53,7 @@ export class CampaignModel extends BaseModel {
     data.dueDate = this.dueDate;
     data.copy = this.copy;
     data.zone = this.zone;
+    data.approved = this.approved;
     return data;
   }
 

--- a/src/app/shared/model/campaign.model.ts
+++ b/src/app/shared/model/campaign.model.ts
@@ -1,0 +1,61 @@
+import { BaseModel, HalDoc } from 'ngx-prx-styleguide';
+import { Observable } from 'rxjs/Observable';
+
+export class CampaignModel extends BaseModel {
+  public id: number;
+  public startDate: Date;
+  public endDate: Date;
+  public dueDate: Date;
+  public copy: string;
+  public zone: string;
+  public approved: boolean = false;
+  public sponsor: HalDoc; //SponsorModel
+
+  SETABLE = ['copy'];
+
+  VALIDATORS = {};
+
+  constructor(podcast: HalDoc, campaign: HalDoc, loadRelated = true) {
+    super();
+    this.init(podcast, campaign, loadRelated);
+  }
+
+  key(): string {
+    if (this.doc) {
+      return `prx.campaign.${this.doc.id}`;
+    }
+  }
+
+  related(): {} {
+    let sponsor = Observable.of(null);
+    if (this.doc && this.doc.has('prx:sponsor')) {
+      sponsor = this.doc.follow('prx:sponsor'); //.map(sDoc => sDoc); //.map(sDoc => { new SponsorModel(sDoc);
+    }
+    return { sponsor: sponsor };
+  }
+
+  decode(): void {
+    this.id = this.doc['id']
+    this.startDate = new Date(this.doc['start_date'])
+    this.endDate = new Date(this.doc['end_date'])
+    this.copy = this.doc['copy'];
+    this.zone = this.doc['zone'];
+    this.dueDate = this.doc['due_date'] ? new Date(this.doc['due_date']) : new Date(); // TODO add due date to campaigns
+    this.approved = this.doc['approved']; // TODO add approved to campaigns
+  }
+
+  encode(): {} {
+    let data = <any> {};
+    data.id = this.id;
+    data.startDate = this.startDate;
+    data.endDate = this.endDate;
+    data.dueDate = this.dueDate;
+    data.copy = this.copy;
+    data.zone = this.zone;
+    return data;
+  }
+
+  saveNew(data: {}): Observable<HalDoc> {
+    return Observable.throw(new Error('Cannot directly create a jingle campaign'));
+  }
+}

--- a/src/app/shared/model/campaign.model.ts
+++ b/src/app/shared/model/campaign.model.ts
@@ -1,5 +1,6 @@
 import { BaseModel, HalDoc } from 'ngx-prx-styleguide';
 import { Observable } from 'rxjs/Observable';
+import { SponsorModel } from './sponsor.model'
 
 export class CampaignModel extends BaseModel {
   public id: number;
@@ -8,8 +9,8 @@ export class CampaignModel extends BaseModel {
   public dueDate: Date;
   public copy: string;
   public zone: string;
-  public approved: boolean = false;
-  public sponsor: HalDoc; //SponsorModel
+  public approved = false;
+  public sponsor: SponsorModel;
 
   SETABLE = ['copy'];
 
@@ -29,15 +30,15 @@ export class CampaignModel extends BaseModel {
   related(): {} {
     let sponsor = Observable.of(null);
     if (this.doc && this.doc.has('prx:sponsor')) {
-      sponsor = this.doc.follow('prx:sponsor'); //.map(sDoc => sDoc); //.map(sDoc => { new SponsorModel(sDoc);
+      sponsor = this.doc.follow('prx:sponsor').map(sDoc => new SponsorModel(sDoc));
     }
     return { sponsor: sponsor };
   }
 
   decode(): void {
-    this.id = this.doc['id']
-    this.startDate = new Date(this.doc['start_date'])
-    this.endDate = new Date(this.doc['end_date'])
+    this.id = this.doc['id'];
+    this.startDate = new Date(this.doc['start_date']);
+    this.endDate = new Date(this.doc['end_date']);
     this.copy = this.doc['copy'];
     this.zone = this.doc['zone'];
     this.dueDate = this.doc['due_date'] ? new Date(this.doc['due_date']) : new Date(); // TODO add due date to campaigns
@@ -45,7 +46,7 @@ export class CampaignModel extends BaseModel {
   }
 
   encode(): {} {
-    let data = <any> {};
+    const data = <any> {};
     data.id = this.id;
     data.startDate = this.startDate;
     data.endDate = this.endDate;

--- a/src/app/shared/model/creative.model.spec.ts
+++ b/src/app/shared/model/creative.model.spec.ts
@@ -1,0 +1,23 @@
+import { Observable } from 'rxjs/Observable';
+import { MockHalDoc } from 'ngx-prx-styleguide';
+import { CreativeModel } from './creative.model';
+
+describe('CreativeModel', () => {
+
+  const makeCreative = (data?: any) => {
+    const campaignDoc = new MockHalDoc({copy: 'test-campaign'});
+    const creativeDoc = new MockHalDoc(data);
+    return new CreativeModel(campaignDoc, creativeDoc);
+  };
+
+  it('loads data from the haldoc', () => {
+    const creative = makeCreative({filename: 'creative-one'});
+    expect(creative.filename).toEqual('creative-one');
+    expect(creative.isNew).toBeFalsy();
+  });
+
+  it('uses the creative id for the key', () => {
+    expect(makeCreative({id: 'creative-id'}).key()).toContain('.creative-id');
+  });
+
+});

--- a/src/app/shared/model/creative.model.spec.ts
+++ b/src/app/shared/model/creative.model.spec.ts
@@ -20,4 +20,10 @@ describe('CreativeModel', () => {
     expect(makeCreative({id: 'creative-id'}).key()).toContain('.creative-id');
   });
 
+  it('uses the campaign id for a new creative key', () => {
+    const newCreative = new CreativeModel(new MockHalDoc({id: 'campaign-id'}), null);
+    expect(newCreative.key()).toContain('.new');
+    expect(newCreative.key()).toContain('.campaign-id');
+  });
+
 });

--- a/src/app/shared/model/creative.model.spec.ts
+++ b/src/app/shared/model/creative.model.spec.ts
@@ -24,6 +24,7 @@ describe('CreativeModel', () => {
     const newCreative = new CreativeModel(new MockHalDoc({id: 'campaign-id'}), null);
     expect(newCreative.key()).toContain('.new');
     expect(newCreative.key()).toContain('.campaign-id');
+    expect(newCreative.isNew).toBeTruthy();
   });
 
 });

--- a/src/app/shared/model/creative.model.ts
+++ b/src/app/shared/model/creative.model.ts
@@ -28,6 +28,8 @@ export class CreativeModel extends BaseModel {
   key(): string {
     if (this.doc) {
       return `prx.creative.${this.doc.id}`;
+    } else {
+      return `prx.creative.new.${this.parent.id}` // new creative in existing campaign
     }
   }
 

--- a/src/app/shared/model/creative.model.ts
+++ b/src/app/shared/model/creative.model.ts
@@ -1,0 +1,77 @@
+import { BaseModel, HalDoc } from 'ngx-prx-styleguide';
+import { Observable } from 'rxjs/Observable';
+
+export class CreativeModel extends BaseModel {
+  public id: number;
+  public status: string;
+  public filename: string;
+  public zone: string;
+  public size: number;
+  public contentType: string;
+  public label: string;
+  public length: number;
+  public layer: number;
+  public bitRate: number;
+  public channelMode: string;
+  public uploadPath: string;
+  public format: string;
+
+  SETABLE = []; // TODO
+
+  VALIDATORS = {}; // TODO
+
+  constructor(campaign: HalDoc, creative: HalDoc, loadRelated = true) {
+    super();
+    this.init(campaign, creative, loadRelated);
+  }
+
+  key(): string {
+    if (this.doc) {
+      return `prx.creative.${this.doc.id}`;
+    }
+  }
+
+  related(): {} {
+    return {};
+  }
+
+  decode(): void {
+    this.id = this.doc['id'];
+    this.status = this.doc['status'];
+    this.filename = this.doc['filename'];
+    this.zone = this.doc['zone'];
+    this.size = this.doc['size'];
+    this.contentType = this.doc['contentType'];
+    this.label = this.doc['label'];
+    this.length = this.doc['length'];
+    this.layer = this.doc['layer'];
+    this.bitRate = this.doc['bitRate'];
+    if (this.bitRate) { this.bitRate = this.bitRate * 1000; }
+    this.channelMode = this.doc['channelMode'];
+    this.uploadPath = this.doc['uploadPath'];
+    this.format = this.doc['format'];
+  }
+
+  encode(): {} {
+    const data = <any> {};
+    data.id = this.id;
+    data.status = this.status;
+    data.filename = this.filename;
+    data.zone = this.zone;
+    data.size = this.size;
+    data.contentType = this.contentType;
+    data.label = this.label;
+    data.length = this.length;
+    data.layer = this.layer;
+    data.bitRate = this.bitRate;
+    data.channelMode = this.channelMode;
+    data.uploadPath = this.uploadPath;
+    data.format = this.format;
+    return data;
+  }
+
+  saveNew(data: {}): Observable<HalDoc> {
+    // when time to implement this, look to Uploadable Model from Publish
+    return this.parent.create('prx:creative', {}, data).map(doc => doc);
+  }
+}

--- a/src/app/shared/model/index.ts
+++ b/src/app/shared/model/index.ts
@@ -1,0 +1,1 @@
+export * from './podcast.model';

--- a/src/app/shared/model/index.ts
+++ b/src/app/shared/model/index.ts
@@ -1,2 +1,3 @@
-export * from './podcast.model';
 export * from './campaign.model';
+export * from './podcast.model';
+export * from './sponsor.model';

--- a/src/app/shared/model/index.ts
+++ b/src/app/shared/model/index.ts
@@ -1,1 +1,2 @@
 export * from './podcast.model';
+export * from './campaign.model';

--- a/src/app/shared/model/podcast.model.spec.ts
+++ b/src/app/shared/model/podcast.model.spec.ts
@@ -1,0 +1,1 @@
+// TODO add tests

--- a/src/app/shared/model/podcast.model.spec.ts
+++ b/src/app/shared/model/podcast.model.spec.ts
@@ -1,1 +1,30 @@
-// TODO add tests
+import { Observable } from 'rxjs/Observable';
+import { MockHalDoc } from 'ngx-prx-styleguide';
+import { PodcastModel } from './podcast.model';
+
+describe('PodcastModel', () => {
+
+  const makePodcast = (data?: any, extra: any = {} ) => {
+    const pDoc = new MockHalDoc(data);
+    pDoc.mockItems('prx:campaigns', extra.campaigns || []);
+    return new PodcastModel(pDoc);
+  }
+
+  it('loads data from the haldoc', () => {
+    let podcast = makePodcast({name: 'Hello World'});
+    expect(podcast.name).toEqual('Hello World');
+    expect(podcast.isNew).toBeFalsy();
+  });
+
+  it('uses the podcast id for the key', () => {
+    expect(makePodcast({id: 'podcast-id'}).key()).toContain('.podcast-id');
+  });
+
+  it('loads related campaigns', () => {
+    let campaigns = [{id: 'campaign-one'}, {id: 'campaign-two'}];
+    let podcast = makePodcast({name: 'foo'}, {campaigns: campaigns});
+    expect(podcast.campaigns.length).toEqual(2);
+  });
+
+
+});

--- a/src/app/shared/model/podcast.model.spec.ts
+++ b/src/app/shared/model/podcast.model.spec.ts
@@ -8,10 +8,10 @@ describe('PodcastModel', () => {
     const pDoc = new MockHalDoc(data);
     pDoc.mockItems('prx:campaigns', extra.campaigns || []);
     return new PodcastModel(pDoc);
-  }
+  };
 
   it('loads data from the haldoc', () => {
-    let podcast = makePodcast({name: 'Hello World'});
+    const podcast = makePodcast({name: 'Hello World'});
     expect(podcast.name).toEqual('Hello World');
     expect(podcast.isNew).toBeFalsy();
   });
@@ -21,10 +21,9 @@ describe('PodcastModel', () => {
   });
 
   it('loads related campaigns', () => {
-    let campaigns = [{id: 'campaign-one'}, {id: 'campaign-two'}];
-    let podcast = makePodcast({name: 'foo'}, {campaigns: campaigns});
+    const campaigns = [{id: 'campaign-one'}, {id: 'campaign-two'}];
+    const podcast = makePodcast({name: 'foo'}, {campaigns: campaigns});
     expect(podcast.campaigns.length).toEqual(2);
   });
-
 
 });

--- a/src/app/shared/model/podcast.model.ts
+++ b/src/app/shared/model/podcast.model.ts
@@ -1,9 +1,9 @@
 import { BaseModel, HalDoc } from 'ngx-prx-styleguide';
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/forkJoin';
 
 export class PodcastModel extends BaseModel {
   public id: number;
-  public doc: HalDoc;
   public name: string;
   public network: string;
   public notes: string;

--- a/src/app/shared/model/podcast.model.ts
+++ b/src/app/shared/model/podcast.model.ts
@@ -1,0 +1,68 @@
+import { BaseModel, HalDoc } from 'ngx-prx-styleguide';
+import { Observable } from 'rxjs/Observable';
+
+export class PodcastModel extends BaseModel {
+  public id: number;
+  public doc: HalDoc;
+  public name: string;
+  public network: string;
+  public notes: string;
+  public rate: string;
+  public structure: string;
+  public recordingDay: string;
+  public campaigns = []; //CampaignModel[] = [];
+
+  SETABLE = []; // podcasts are read only
+
+  VALIDATORS = {};
+
+  constructor(podcast: HalDoc, loadRelated = true) {
+    super();
+    this.init(null, podcast, loadRelated);
+  }
+
+  key(): string {
+    if (this.doc) {
+      return `prx.podcast.${this.doc.id}`;
+    }
+  }
+
+  related(): {} {
+    let campaigns = Observable.of([]);
+    if (this.doc && this.doc.has('prx:campaigns')) {
+      console.log('has campaigns')
+      campaigns = this.doc.followItems('prx:campaigns'); // turn to CampaignModel
+    }
+    return { campaigns: campaigns };
+  }
+
+  decode(): void {
+    this.id = this.doc['id'];
+    this.name = this.doc['name'];
+    this.network = this.doc['network'];
+    this.notes = this.doc['notes'];
+    this.rate = this.doc['rate'];
+    this.structure = this.doc['structure'];
+    this.recordingDay = this.doc['recordingDay'];
+  }
+
+  encode(): {} {
+    let data = <any> {};
+    data.id = this.id;
+    data.name = this.name;
+    data.network = this.network;
+    data.notes = this.notes;
+    data.rate = this.rate;
+    data.structure = this.structure;
+    data.recordingDay = this.recordingDay;
+    // data.campaigns = this.campaigns;
+
+    // data.field = this.field;
+    // returns an object with the model's data used in persisting the underlying HalDoc
+    return data;
+  }
+
+  saveNew(data: {}): Observable<HalDoc> {
+    return Observable.throw(new Error('Cannot directly create a jingle podcast'));
+  }
+}

--- a/src/app/shared/model/podcast.model.ts
+++ b/src/app/shared/model/podcast.model.ts
@@ -1,3 +1,4 @@
+import { CampaignModel } from './campaign.model';
 import { BaseModel, HalDoc } from 'ngx-prx-styleguide';
 import { Observable } from 'rxjs/Observable';
 
@@ -9,7 +10,7 @@ export class PodcastModel extends BaseModel {
   public rate: string;
   public structure: string;
   public recordingDay: string;
-  public campaigns = []; //CampaignModel[] = [];
+  public campaigns: CampaignModel[] = [];
 
   SETABLE = []; // podcasts are read only
 
@@ -29,7 +30,9 @@ export class PodcastModel extends BaseModel {
   related(): {} {
     let campaigns = Observable.of([]);
     if (this.doc && this.doc.has('prx:campaigns')) {
-      campaigns = this.doc.followItems('prx:campaigns'); // turn to CampaignModel
+      campaigns = this.doc.followItems('prx:campaigns').map(cDocs => {
+        return cDocs.map(c => new CampaignModel(this.doc, c));
+      });
     }
     return { campaigns: campaigns };
   }

--- a/src/app/shared/model/podcast.model.ts
+++ b/src/app/shared/model/podcast.model.ts
@@ -1,6 +1,5 @@
 import { BaseModel, HalDoc } from 'ngx-prx-styleguide';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/forkJoin';
 
 export class PodcastModel extends BaseModel {
   public id: number;

--- a/src/app/shared/model/podcast.model.ts
+++ b/src/app/shared/model/podcast.model.ts
@@ -29,7 +29,6 @@ export class PodcastModel extends BaseModel {
   related(): {} {
     let campaigns = Observable.of([]);
     if (this.doc && this.doc.has('prx:campaigns')) {
-      console.log('has campaigns')
       campaigns = this.doc.followItems('prx:campaigns'); // turn to CampaignModel
     }
     return { campaigns: campaigns };
@@ -46,19 +45,7 @@ export class PodcastModel extends BaseModel {
   }
 
   encode(): {} {
-    let data = <any> {};
-    data.id = this.id;
-    data.name = this.name;
-    data.network = this.network;
-    data.notes = this.notes;
-    data.rate = this.rate;
-    data.structure = this.structure;
-    data.recordingDay = this.recordingDay;
-    // data.campaigns = this.campaigns;
-
-    // data.field = this.field;
-    // returns an object with the model's data used in persisting the underlying HalDoc
-    return data;
+    return {}; // podcasts are read only
   }
 
   saveNew(data: {}): Observable<HalDoc> {

--- a/src/app/shared/model/sponsor.model.spec.ts
+++ b/src/app/shared/model/sponsor.model.spec.ts
@@ -1,0 +1,21 @@
+import { MockHalDoc } from 'ngx-prx-styleguide';
+import { SponsorModel } from './sponsor.model';
+
+describe('SponsorModel', () => {
+
+  const makeSponsor = (data?: any, extra: any = {} ) => {
+    const sDoc = new MockHalDoc(data);
+    return new SponsorModel(sDoc);
+  };
+
+  it('loads data from the haldoc', () => {
+    const sponsor = makeSponsor({notes: 'World\s best sponsor'});
+    expect(sponsor.notes).toEqual('World\s best sponsor');
+    expect(sponsor.isNew).toBeFalsy();
+  });
+
+  it('uses the sponsor id for the key', () => {
+    expect(makeSponsor({id: 'sponsor-id'}).key()).toContain('.sponsor-id');
+  });
+
+});

--- a/src/app/shared/model/sponsor.model.ts
+++ b/src/app/shared/model/sponsor.model.ts
@@ -1,0 +1,43 @@
+import { BaseModel, HalDoc } from 'ngx-prx-styleguide';
+import { Observable } from 'rxjs/Observable';
+
+export class SponsorModel extends BaseModel {
+  public id: number;
+  public notes: string;
+  public name: string;
+  public billingInfo: string;
+
+  SETABLE = [];
+
+  VALIDATORS = {};
+
+  constructor(sponsor: HalDoc, loadRelated = true) {
+    super();
+    this.init(null, sponsor, loadRelated);
+  }
+
+  key(): string {
+    if (this.doc) {
+      return `prx.sponsor.${this.doc.id}`;
+    }
+  }
+
+  related(): {} {
+    return {};
+  }
+
+  decode(): void {
+    this.id = this.doc['id'];
+    this.name = this.doc['name'];
+    this.notes = this.doc['notes'];
+    this.billingInfo = this.doc['billing_info'];
+  }
+
+  encode(): {} {
+    return {}; // sponsors are read only
+  }
+
+  saveNew(data: {}): Observable<HalDoc> {
+    return Observable.throw(new Error('Cannot directly create a jingle sponsor'));
+  }
+}

--- a/src/app/shared/model/sponsor.model.ts
+++ b/src/app/shared/model/sponsor.model.ts
@@ -30,7 +30,7 @@ export class SponsorModel extends BaseModel {
     this.id = this.doc['id'];
     this.name = this.doc['name'];
     this.notes = this.doc['notes'];
-    this.billingInfo = this.doc['billing_info'];
+    this.billingInfo = this.doc['billingInfo'];
   }
 
   encode(): {} {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3562,9 +3562,9 @@ newrelic@^2.3.1:
   optionalDependencies:
     "@newrelic/native-metrics" "^2.1.0"
 
-ngx-prx-styleguide@^0.0.19:
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-0.0.19.tgz#19abc33d697c986d51b8c5e61277c042f632cec7"
+ngx-prx-styleguide@^0.0.20:
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-0.0.20.tgz#7956faed96f34d53166c6ad88bba44dc30c41728"
   dependencies:
     angular-2-dropdown-multiselect "^1.5.4"
     c3 "^0.4.11"


### PR DESCRIPTION
#15: adding in models that inherit from the styleguide's BaseModel. 
Podcasts, Sponsors, and Campaigns will not be created through this UI -- those will be created in Jingle via the google form (for now) and/or AdBook (down the line). So those are read-only in Adflow, with the exception of the copy for a campaign, which the producer will be able to edit or craft anew entirely. Creatives are the only thing that will be created (sorry for confusing wording) through this UI, but we haven't gotten to how we'll do that yet so for now that model is just a skeleton (eventually we'll want to port over much of the same logic from UploadableModel in publish). 